### PR TITLE
Refactor CowboyHatItem and LivingEntityMixin to ensure cowboy functionality

### DIFF
--- a/src/main/java/it/hurts/octostudios/rarcompat/items/hat/CowboyHatItem.java
+++ b/src/main/java/it/hurts/octostudios/rarcompat/items/hat/CowboyHatItem.java
@@ -28,12 +28,14 @@ import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.FlyingMob;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.Saddleable;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
 import net.minecraft.world.entity.ai.attributes.Attributes;
 import net.minecraft.world.entity.ambient.AmbientCreature;
 import net.minecraft.world.entity.animal.FlyingAnimal;
 import net.minecraft.world.entity.animal.WaterAnimal;
+import net.minecraft.world.entity.animal.horse.AbstractHorse;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 import net.minecraft.world.entity.boss.wither.WitherBoss;
 import net.minecraft.world.entity.monster.ElderGuardian;
@@ -121,43 +123,53 @@ public class CowboyHatItem extends WearableRelicItem {
     @Override
     public void curioTick(SlotContext slotContext, ItemStack stack) {
         if (!(slotContext.entity() instanceof Player player) || !(player.getRootVehicle() instanceof Mob beingMounted)
-                || !getToggled(stack) || !checkMob(player, EnderDragon.class, WitherBoss.class, Warden.class, ElderGuardian.class))
+                || !checkMob(player, EnderDragon.class, WitherBoss.class, Warden.class, ElderGuardian.class)
+                || (beingMounted instanceof AbstractHorse && !((AbstractHorse) beingMounted).isTamed()))
             return;
 
-        if (isAbilityOnCooldown(stack, "overlord") || !isAbilityUnlocked(stack, "overlord"))
-            player.stopRiding();
-        else {
-            var random = player.getRandom();
-            var level = player.getCommandSenderWorld();
+        var random = player.getRandom();
+        var level = player.getCommandSenderWorld();
 
-            if (getTime(stack) >= getStatValue(stack, "overlord", "time") * 20) {
-                player.stopRiding();
-                player.playSound(SoundEvents.WOOL_HIT, 1.0F, 0.9F + player.getRandom().nextFloat() * 0.2F);
+        // Ensure Overlord ability does not interfere with cowboy ability by applying cowboy ability first
+        if(isAbilityUnlocked(stack, "cowboy")){
+            if (level.isClientSide() && player instanceof LocalPlayer localPlayer
+                    && localPlayer.input.jumping && beingMounted.onGround()
+                    && !isWaterOrFlyingMob(beingMounted) && !(beingMounted instanceof AbstractHorse))
+                beingMounted.addDeltaMovement(new Vec3(0, 0.8, 0));
 
-                setTime(stack, 0);
+            // Ensure experience is applied only while moving
+            var knownMovement = beingMounted.getKnownMovement();
+            if ((knownMovement.x != 0 || knownMovement.z != 0) && random.nextFloat() <= 0.25F && player.tickCount % 20 == 0)
+                spreadRelicExperience(player, stack, 1);
 
-                for (int i = 0; i < 50; i++)
-                    level.addParticle(ParticleUtils.constructSimpleSpark(new Color(150 + random.nextInt(106), 50 + random.nextInt(100), 50 + random.nextInt(100)),
-                                    0.5F, 60, 0.95F),
-                            player.getX(), player.getY() + 1.0, player.getZ(),
-                            (random.nextDouble() - 0.5) * 3.0,
-                            random.nextDouble() * 1.5,
-                            (random.nextDouble() - 0.5) * 3.0);
-            } else {
-                if (level.isClientSide() && player instanceof LocalPlayer localPlayer && localPlayer.input.jumping && beingMounted.onGround()
-                        && !isWaterOrFlyingMob(beingMounted))
-                    beingMounted.addDeltaMovement(new Vec3(0, 0.8, 0));
+            changeAttributes(beingMounted, stack, true, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
+        } else {
+            // Ensure attributes are not applied
+            changeAttributes(beingMounted, stack, false, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
+        }
 
-                var knownMovement = beingMounted.getKnownMovement();
+        // Handle overlord ability
+        if (getToggled(stack) && isAbilityUnlocked(stack, "overlord")){
+            // Stop riding if the ability is on cooldown
+           if (isAbilityOnCooldown(stack, "overlord")){
+               player.stopRiding();
+           } else if (getTime(stack) >= getStatValue(stack, "overlord", "time") * 20) {
+               player.stopRiding();
+               // Play sound and display particles
+               player.playSound(SoundEvents.WOOL_HIT, 1.0F, 0.9F + player.getRandom().nextFloat() * 0.2F);
 
-                if ((knownMovement.x != 0 || knownMovement.z != 0) && random.nextFloat() <= 0.25F && player.tickCount % 20 == 0)
-                    spreadRelicExperience(player, stack, 1);
+               for (int i = 0; i < 50; i++)
+                   level.addParticle(ParticleUtils.constructSimpleSpark(new Color(150 + random.nextInt(106), 50 + random.nextInt(100), 50 + random.nextInt(100)),
+                                   0.5F, 60, 0.95F),
+                           player.getX(), player.getY() + 1.0, player.getZ(),
+                           (random.nextDouble() - 0.5) * 3.0,
+                           random.nextDouble() * 1.5,
+                           (random.nextDouble() - 0.5) * 3.0);
 
-                if (isAbilityUnlocked(stack, "cowboy"))
-                    changeAttributes(beingMounted, stack, true, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
-
-                addTime(stack, 1);
-            }
+               resetOverlordState(stack, beingMounted);
+           } else {
+               addTime(stack, 1);
+           }
         }
     }
 
@@ -232,6 +244,16 @@ public class CowboyHatItem extends WearableRelicItem {
         return stack.getOrDefault(DataComponentRegistry.TOGGLED, false);
     }
 
+    private void resetOverlordState(ItemStack stack, Mob beingMounted) {
+        if (stack.isEmpty() || !(stack.getItem() instanceof CowboyHatItem relic))
+            return;
+
+        relic.addAbilityCooldown(stack, "overlord", 600);
+        relic.setTime(stack, 0);
+        relic.setToggled(stack, false);
+        relic.changeAttributes(beingMounted, stack, false, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
+    }
+
     @EventBusSubscriber
     public static class CowboyEvent {
         @SubscribeEvent
@@ -241,14 +263,34 @@ public class CowboyHatItem extends WearableRelicItem {
 
             var stack = EntityUtils.findEquippedCurio(player, ModItems.COWBOY_HAT.value());
 
-            if (player.getCommandSenderWorld().isClientSide() || !(stack.getItem() instanceof CowboyHatItem relic) || !event.isDismounting()
-                    || !(event.getEntityBeingMounted() instanceof Mob mount) || !relic.getToggled(stack))
+            if (player.getCommandSenderWorld().isClientSide() || !(stack.getItem() instanceof CowboyHatItem relic)
+                    || !event.isDismounting() || !(event.getEntityBeingMounted() instanceof Mob mount)
+                    || !relic.getToggled(stack))
+                        return;
+
+            relic.resetOverlordState(stack, mount);
+        }
+
+        @SubscribeEvent
+        public static void onEntityDismount(EntityMountEvent event) {
+            Entity entity = event.getEntityBeingMounted();
+            Entity rider = event.getEntityMounting();
+
+            if (!(rider instanceof Player player))
                 return;
 
-            relic.addAbilityCooldown(stack, "overlord", 600);
-            relic.setTime(stack, 0);
-            relic.setToggled(stack, false);
-            relic.changeAttributes(mount, stack, false, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
+            // Check if the player has the Cowboy Hat equipped
+            ItemStack stack = EntityUtils.findEquippedCurio(player, ModItems.COWBOY_HAT.value());
+
+            if (stack.isEmpty() || !(stack.getItem() instanceof CowboyHatItem relic))
+                return;
+
+            if (event.isDismounting() && entity instanceof Mob mob && entity instanceof Saddleable) {
+                // Apply attribute removal on the server side
+                if (!player.getCommandSenderWorld().isClientSide()) {
+                    relic.changeAttributes(mob, stack, false, Attributes.MOVEMENT_SPEED, Attributes.JUMP_STRENGTH, Attributes.SAFE_FALL_DISTANCE);
+                }
+            }
         }
     }
 }

--- a/src/main/java/it/hurts/octostudios/rarcompat/mixin/LivingEntityMixin.java
+++ b/src/main/java/it/hurts/octostudios/rarcompat/mixin/LivingEntityMixin.java
@@ -24,8 +24,10 @@ abstract class LivingEntityMixin {
     private void travelRidden(Player player, Vec3 vec, CallbackInfo ci) {
         ItemStack stack = EntityUtils.findEquippedCurio(player, ModItems.COWBOY_HAT.value());
 
-        if (!((LivingEntity) (Object) this instanceof Mob mounted) || !(stack.getItem() instanceof CowboyHatItem relic)
-                || !relic.getToggled(stack))
+        if (stack.isEmpty() || !(stack.getItem() instanceof CowboyHatItem relic))
+            return;
+
+        if (!((LivingEntity) (Object) this instanceof Mob mounted))
             return;
 
         if (!mounted.isControlledByLocalInstance()) {
@@ -34,19 +36,29 @@ abstract class LivingEntityMixin {
             mounted.calculateEntityAnimation(false);
         }
 
-        var speed = player.getSpeed();
-
-        mounted.setTarget(null);
-        mounted.setSpeed((float) (speed + (speed * relic.getStatValue(stack, "cowboy", "speed") * 2)));
+        // Handle passive Cowboy ability (speed buff enhancements)
+        if (relic.isAbilityUnlocked(stack, "cowboy")) {
+            var speed = player.getSpeed();
+            mounted.setTarget(null); // Reset mob's target to avoid conflicts
+            mounted.setSpeed((float) (speed + (speed * relic.getStatValue(stack, "cowboy", "speed") * 2)));
+        }
 
         rarcompat$tickRidden(mounted, player);
 
-        if (relic.isWaterOrFlyingMob(mounted))
-            rarcompat$travel(rarcompat$getRiddenInput(player, relic, mounted), mounted);
-        else
-            mounted.travel(rarcompat$getRiddenInput(player, relic, mounted));
-
-        ci.cancel();
+        // Handle travel (default for Cowboy, custom for Overlord if toggled)
+        Vec3 riddenInput = rarcompat$getRiddenInput(player, relic, mounted);
+        if (relic.getToggled(stack) && relic.isAbilityUnlocked(stack, "overlord")) {
+            // Overlord-specific travel logic
+            if (relic.isWaterOrFlyingMob(mounted)) {
+                rarcompat$travel(riddenInput, mounted);
+            } else {
+                mounted.travel(riddenInput);
+            }
+            ci.cancel(); // Cancel default behavior when Overlord is active
+        } else {
+            // Default travel for Cowboy ability
+            mounted.travel(riddenInput);
+        }
     }
 
     @Unique


### PR DESCRIPTION
# Overview

While playing the ATM10 pack, I noticed that the cowboy hat was not affecting the horse I was riding. Additionally, experience was not being gained while I was riding the horse. This applied to all saddleable entities, which included the pig and strider.

I created a test world with the following mod versions and confirmed that the functionality for the Cowboy Hat was not working as expected.

- Artifacts - 13.0.2
- Cloth-Config - 15.0.128
- ExpandAbility - 12.0.0
- Curios API - 9.0.9+1.21
- Relics - 0.10.6.0
- Architectury - 13.0.6
- Octolib - 0.5.0.1
- NeoForge - 21.1.133
- RAR-Compat - 0.9.6

This PR is to address those issues being experienced.

Please let me know if there are any additional questions or changes needed. I freely admit I'm not completely familiar with desired code style (though I did try to keep it consistent, minus the addition of several comments in places they felt most appropriate) or additional functionality that may exist outside of the rar-compat mod.

# Class Modifications
## CowboyHatItem.java
Several modifications were made to both the `curioTick` method as well as the the addition of the `onEntityDismount` subscription event method.

In the `curioTick` method, a check was done at the start to ensure that if a horse is not tamed, yet the user has mounted it to tame it while wearing the cowboy hat item, it won't have the attribute boosts applied. This allows for the vanilla movements of the horse as it's being tamed. Once it is tamed, and the user has the hat on, the attributes will be applied.

Additionally, the structure of the method code was slightly changed. This was done to address the following assumptions:
1. The `cowboy` ability is a passive ability (i.e. it does not need to be trigged and therefore it's benefits should be applied if the relic is on the player)
2. The vanilla jump bar functionality should exist for horses while wearing the relic
3. Experience should still be gained while the player has the cowboy hat in the curio slot and it's not gated behind an ability being toggled.

A callout here is that for the check of if the player is jumping  while the entity is on the ground, which I believe is there to handle entities that should not be able to jump (i.e. mobs that are not the horse), the vertical movement being added interfered with the jump bar functionality while mounted on a horse. Attempting to hold space to fill the jump bar would cause the horse to jump immediately, and not respect the jump bar fill. Multiple jumps would take place due to the holding of the space bar. I assumed that this was not intended behavior. To address this, a check was added to ensure the entity was not the horse.

Finally, I added a second subscribe event for handling when the player is dismounting from an entity. There were usecases where when dismounting from a saddled pig or strider, the entity would keep the boosted attributes. This ensures that saddleable entities have their attributes reset when the player is dismounting.

## LivingEntityMixin.java
The changes here in the `travelRidden` method removed the check for if the relic had been toggled. This prevented the speed boost from being applied since the relic is only toggled when the `overlord` ability is triggered.

The logic for applying the speed boost was done prior to the logic that was in place for the `overlord` ability. From my assumptions on the intent of the code, the same travel is called but is more clearly outlined for when the `overlord` ability is being triggered. Without this, the cowboy hat was not providing the expected boosts to entities unless `overlord` was being used.

# Testing

The following outlines the testing done to ensure functionality works as expected. It included ensuring that experience was gained from riding mountable entities (horses, pigs, striders), as well as ensure that the `overlord` ability continued to have the proper alt-menu option and cooldown.

Finally, tests took place on a single player creative world switching between survival and creative as well as being tested on a server with a client connected.

> Note - Not all mobs were tested but a majority was done to where confidence was high that functionality is working as intended

Entities tested included:
## Horse, Pig, Strider

- [x] Can mount horse with hat on and attributes are applied
- [x] While mounted with hat on, backwards and sideway motion speeds are restricted
- [x] Jump strength is increased as expected with hat on per hat level and stats
- [x] Movement speed is increased with hat on per hat level and stats
- [x] Safe fall distance is increased with hat on per hat level and stats
- [x] Dismounting from horse resets increased attributes
- [x] Dismounting from strider resets increased attributes
- [x] Dismounting from pig resets increased attributes
- [x] Mounting either horse, pig, or strider without cowboy hat in curio slot does not give boosted attributes
- [x] (Horse) When taming a horse attributes are not applied until the horse is tamed

## Entities

- [x] Player can mount the entity with `overlord` ability active
- [x] Player is dismounted at specified end time of ability
- [x] Mounted entity does not have increased movement, jump, or fall damage attributes
- [x] Can jump with entity as high as player jump (i.e. jump strength isn't applied as expected)
- [x] Attempting to left click while `overlord` is still on cooldown does not allow the player to mount entity
- [x] Cooldown functionality continues to work as expected

| Name              | Result       |
| ----------------- | ------------ |
| Panda             | Pass |
| Iron Golen        | Pass |
| Wandering Trader  | Pass |
| Husk              | Pass |
| Zombie            | Pass |
| Baby Zombie       | Pass |
| Baby Horse        | Pass |
| Slime             | Pass |
| Enderman          | Pass |
| Wolf              | Pass |
| Tamed Wolf        | Pass |
| Zomblified Piglin | Pass |
| Wither Skeleton   | Pass |

## Flying and Water Entities

- [x] Can mount entity with `overlord` ability active
- [x] Player is dismounted at specified time of ability
- [x] Mounted Entity Reverts applied attributes as expected
- [x] On dismount entity has applied attributes removed
- [x] Player cannot mount entity without Cowboy hat in curio head slot
- [x] Player jumping does not apply. Meaning that to move up the player must look up
- [x] On mob death (i.e. in the case of Phantom in daylight being burned, fish on land) - the player is dismounted as expected
- [x] Cooldown functionality continues to work as expected

| Entity Name   | Result       |
| ------------- | ------------ |
| Tropical Fish | Pass |
| Dolphin       | Pass |
| Parrot        | Pass |
| Phantom       | Pass |
| Tadpole       | Pass |

## Restricted Mods

- [x] Cannot mount Ender Dragon, Wither, Warden, or Elder Guardian with `overlord` ability